### PR TITLE
Fix: 1.2.0 버그 수정

### DIFF
--- a/core/ui/src/main/java/com/poptato/ui/common/CategoryIconBottomSheet.kt
+++ b/core/ui/src/main/java/com/poptato/ui/common/CategoryIconBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.poptato.ui.common
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -43,8 +44,12 @@ import com.poptato.domain.model.response.category.CategoryIconTypeListModel
 @Composable
 fun CategoryIconBottomSheet(
     categoryIconList: CategoryIconTotalListModel = CategoryIconTotalListModel(),
-    onSelectCategoryIcon: (CategoryIconItemModel) -> Unit = {}
+    onSelectCategoryIcon: (CategoryIconItemModel) -> Unit = {},
+    onClickBackButton: () -> Unit,
 ) {
+    BackHandler {
+        onClickBackButton()
+    }
 
     CategoryBottomSheetContent(
         categoryIconList = categoryIconList,

--- a/core/ui/src/main/java/com/poptato/ui/util/DismissKeyboardOnClick.kt
+++ b/core/ui/src/main/java/com/poptato/ui/util/DismissKeyboardOnClick.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 
 @Composable
 fun DismissKeyboardOnClick(
+    callback: () -> Unit = {},
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
@@ -33,6 +34,7 @@ fun DismissKeyboardOnClick(
                             inputMethodManager.hideSoftInputFromWindow(it.windowToken, 0)
                         }
                         keyboardController?.hide()
+                        callback()
                     }
                 })
             }

--- a/feature/component/src/main/java/com/poptato/component/todo/TodoItem.kt
+++ b/feature/component/src/main/java/com/poptato/component/todo/TodoItem.kt
@@ -233,15 +233,17 @@ private fun RepeatDeadlineRow(
                 style = PoptatoTypo.xsRegular
             )
 
-            Spacer(modifier = Modifier.width(4.dp))
+            if (item.dDay != null) {
+                Spacer(modifier = Modifier.width(4.dp))
 
-            Text(
-                text = DOT,
-                color = Gray50,
-                style = PoptatoTypo.xsRegular
-            )
+                Text(
+                    text = DOT,
+                    color = Gray50,
+                    style = PoptatoTypo.xsRegular
+                )
 
-            Spacer(modifier = Modifier.width(4.dp))
+                Spacer(modifier = Modifier.width(4.dp))
+            }
         }
 
         if (item.dDay != null) {

--- a/feature/history/src/main/java/com/potato/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/com/potato/history/HistoryScreen.kt
@@ -198,8 +198,7 @@ fun CalendarContent(
         CalendarHeader(
             currentMonth = currentMonthStartDate,
             onPreviousMonthClick = { onPreviousMonthClick() },
-            onNextMonthClick = { onNextMonthClick() },
-            onHeaderClick = { onClickCalendarHeader() }
+            onNextMonthClick = { onNextMonthClick() }
         )
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -249,8 +248,7 @@ fun CalendarContent(
 fun CalendarHeader(
     currentMonth: LocalDate,
     onPreviousMonthClick: () -> Unit,
-    onNextMonthClick: () -> Unit,
-    onHeaderClick: () -> Unit
+    onNextMonthClick: () -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -276,7 +274,7 @@ fun CalendarHeader(
         
         Spacer(modifier = Modifier.width(12.dp))
 
-        IconButton(onClick = onNextMonthClick, modifier = Modifier.size(24.dp), enabled = currentMonth < LocalDate.now().withDayOfMonth(1)) {
+        IconButton(onClick = onNextMonthClick, modifier = Modifier.size(24.dp)) {
             Icon(
                 painter = painterResource(id = R.drawable.ic_arrow_right_20),
                 contentDescription = "Next Month",

--- a/feature/src/main/java/com/poptato/feature/MainScreen.kt
+++ b/feature/src/main/java/com/poptato/feature/MainScreen.kt
@@ -291,6 +291,7 @@ fun MainScreen() {
                             )
                         }
 
+                        // 카테고리 생성 화면 카테고리 리스트 바텀시트
                         BottomSheetType.CategoryIcon -> {
                             CategoryIconBottomSheet(
                                 categoryIconList = uiState.categoryIconList,
@@ -299,7 +300,8 @@ fun MainScreen() {
                                         viewModel.selectedIconInBottomSheet.emit(it)
                                         sheetState.hide()
                                     }
-                                }
+                                },
+                                onClickBackButton = backPressHandler
                             )
                         }
 

--- a/feature/src/main/java/com/poptato/feature/MainScreen.kt
+++ b/feature/src/main/java/com/poptato/feature/MainScreen.kt
@@ -111,6 +111,7 @@ fun MainScreen() {
         scope.launch { sheetState.show() }
     }
     val backPressHandler: () -> Unit = {
+        scope.launch { viewModel.activateItemFlow.emit(-1L) }
         if (sheetState.isVisible) {
             scope.launch { sheetState.hide() }
         } else if (uiState.backPressedOnce) {
@@ -182,7 +183,11 @@ fun MainScreen() {
         }
     }
 
-    DismissKeyboardOnClick {
+    DismissKeyboardOnClick(
+        callback = {
+            scope.launch { viewModel.activateItemFlow.emit(-1L)  }
+        }
+    ) {
         if (isShowDialog.value) {
             when (uiState.dialogContent.dialogType) {
                 DialogType.OneBtn -> {

--- a/feature/today/src/main/java/com/poptato/today/TodayPageState.kt
+++ b/feature/today/src/main/java/com/poptato/today/TodayPageState.kt
@@ -10,5 +10,6 @@ data class TodayPageState(
     val selectedItem: TodoItemModel = TodoItemModel(),
     val isFinishedInitialization: Boolean = false,
     val categoryList: List<CategoryItemModel> = emptyList(),
-    val isDeadlineDateMode: Boolean = false
+    val isDeadlineDateMode: Boolean = false,
+    val isExistYesterdayTodo: Boolean = false
 ) : PageState

--- a/feature/today/src/main/java/com/poptato/today/TodayScreen.kt
+++ b/feature/today/src/main/java/com/poptato/today/TodayScreen.kt
@@ -109,6 +109,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun TodayScreen(
     goToBacklog: () -> Unit = {},
+    goToYesterdayList: () -> Unit = {},
     showSnackBar: (String) -> Unit,
     showBottomSheet: (TodoItemModel, List<CategoryItemModel>) -> Unit = { _, _ -> },
     updateDeadlineFlow: SharedFlow<String?>,
@@ -124,6 +125,13 @@ fun TodayScreen(
     val date = TimeFormatter.getTodayMonthDay()
     var activeItemId by remember { mutableStateOf<Long?>(null) }
     val haptic = LocalHapticFeedback.current
+
+    LaunchedEffect(uiState.isExistYesterdayTodo) {
+        if (uiState.isExistYesterdayTodo) {
+            goToYesterdayList()
+            viewModel.completeYesterdayTodoDisplay()
+        }
+    }
 
     LaunchedEffect(activateItemFlow) {
         activateItemFlow.collect { id ->

--- a/feature/today/src/main/java/com/poptato/today/TodayScreen.kt
+++ b/feature/today/src/main/java/com/poptato/today/TodayScreen.kt
@@ -1,6 +1,7 @@
 package com.poptato.today
 
 import android.annotation.SuppressLint
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.animateDp
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.spring
@@ -54,6 +55,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
@@ -311,6 +313,7 @@ fun TodayTodoList(
     haptic: HapticFeedback = LocalHapticFeedback.current,
     isDeadlineDateMode: Boolean = false
 ) {
+    val focusManager = LocalFocusManager.current
     var draggedItem by remember { mutableStateOf<TodoItemModel?>(null) }
     var isDragging by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
@@ -318,6 +321,10 @@ fun TodayTodoList(
         lazyListState = rememberLazyListState(),
         onMove = onMove
     )
+
+    BackHandler {
+        focusManager.clearFocus()
+    }
 
     LazyColumn(
         state = dragDropState.lazyListState,

--- a/feature/today/src/main/java/com/poptato/today/TodayScreen.kt
+++ b/feature/today/src/main/java/com/poptato/today/TodayScreen.kt
@@ -82,6 +82,7 @@ import com.poptato.design_system.Gray90
 import com.poptato.design_system.Gray95
 import com.poptato.design_system.PoptatoTypo
 import com.poptato.design_system.Primary100
+import com.poptato.design_system.Primary40
 import com.poptato.design_system.Primary60
 import com.poptato.design_system.R
 import com.poptato.design_system.SNACK_BAR_TODAY_ALL_CHECKED
@@ -613,7 +614,7 @@ fun EmptyTodoView(
             modifier = Modifier
                 .size(width = 132.dp, height = 37.dp)
                 .clip(RoundedCornerShape(32.dp))
-                .background(Primary60)
+                .background(Primary40)
                 .clickable { onClickBtnGetTodo() },
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center

--- a/feature/today/src/main/java/com/poptato/today/TodayViewModel.kt
+++ b/feature/today/src/main/java/com/poptato/today/TodayViewModel.kt
@@ -189,24 +189,17 @@ class TodayViewModel @Inject constructor(
 
     fun moveItem(fromIndex: Int, toIndex: Int) {
         val currentList = uiState.value.todayList.toMutableList()
-        val lastIncompleteIndex = currentList.indexOfLast { it.todoStatus == TodoStatus.INCOMPLETE }
-        var safeToIndex = toIndex
+        val firstCompletedIndex = currentList.indexOfFirst { it.todoStatus == TodoStatus.COMPLETED }
 
-        if (lastIncompleteIndex in fromIndex..<toIndex) {
-            safeToIndex = lastIncompleteIndex
-        } else if (lastIncompleteIndex in toIndex..<fromIndex) {
-            safeToIndex = lastIncompleteIndex + 1
-        }
+        if (fromIndex >= firstCompletedIndex || toIndex >= firstCompletedIndex) return
 
-        if (fromIndex != safeToIndex) {
-            AnalyticsManager.logEvent(
-                eventName = "drag_today",
-                params = mapOf("task_ID" to "${uiState.value.todayList[fromIndex].todoId}")
-            )
+        AnalyticsManager.logEvent(
+            eventName = "drag_today",
+            params = mapOf("task_ID" to "${uiState.value.todayList[fromIndex].todoId}")
+        )
 
-            currentList.move(fromIndex, safeToIndex)
-            updateList(currentList)
-        }
+        currentList.move(fromIndex, toIndex)
+        updateList(currentList)
     }
 
     fun onDragEnd() {

--- a/feature/today/src/main/java/com/poptato/today/TodayViewModel.kt
+++ b/feature/today/src/main/java/com/poptato/today/TodayViewModel.kt
@@ -5,6 +5,7 @@ import com.poptato.core.enums.TodoType
 import com.poptato.core.util.TimeFormatter
 import com.poptato.core.util.move
 import com.poptato.domain.model.enums.TodoStatus
+import com.poptato.domain.model.request.ListRequestModel
 import com.poptato.domain.model.request.category.GetCategoryListRequestModel
 import com.poptato.domain.model.request.today.GetTodayListRequestModel
 import com.poptato.domain.model.request.todo.DeadlineContentModel
@@ -31,6 +32,7 @@ import com.poptato.domain.usecase.todo.UpdateDeadlineUseCase
 import com.poptato.domain.usecase.todo.UpdateTodoCategoryUseCase
 import com.poptato.domain.usecase.todo.UpdateTodoCompletionUseCase
 import com.poptato.domain.usecase.todo.UpdateTodoRepeatUseCase
+import com.poptato.domain.usecase.yesterday.GetYesterdayListUseCase
 import com.poptato.ui.base.BaseViewModel
 import com.poptato.ui.util.AnalyticsManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -55,11 +57,13 @@ class TodayViewModel @Inject constructor(
     private val updateTodoCategoryUseCase: UpdateTodoCategoryUseCase,
     private val deleteTodoUseCase: DeleteTodoUseCase,
     private val updateTodoRepeatUseCase: UpdateTodoRepeatUseCase,
-    private val getDeadlineDateModeUseCase: GetDeadlineDateModeUseCase
+    private val getDeadlineDateModeUseCase: GetDeadlineDateModeUseCase,
+    private var getYesterdayListUseCase: GetYesterdayListUseCase
 ) : BaseViewModel<TodayPageState>(TodayPageState()) {
     private var snapshotList: List<TodoItemModel> = emptyList()
 
     init {
+        getYesterdayList(0, 1)
         getDeadlineDateMode()
         getTodayList(0, 50)
         getCategoryList()
@@ -404,5 +408,23 @@ class TodayViewModel @Inject constructor(
                 updateState(uiState.value.copy(isDeadlineDateMode = it))
             }
         }
+    }
+
+    // YesterdayTodo
+    private fun getYesterdayList(page: Int, size: Int) {
+        viewModelScope.launch {
+            getYesterdayListUseCase(request = ListRequestModel(page = page, size = size)).collect {
+                resultResponse(it, { data ->
+                    updateState(uiState.value.copy(isExistYesterdayTodo = data.yesterdays.isNotEmpty()))
+                    Timber.d("[어제 한 일] 서버통신 성공(Backlog) -> $data")
+                }, { error ->
+                    Timber.d("[어제 한 일] 서버통신 실패(Backlog) -> $error")
+                })
+            }
+        }
+    }
+
+    fun completeYesterdayTodoDisplay() {
+        updateState(uiState.value.copy(isExistYesterdayTodo = false))
     }
 }

--- a/feature/yesterdaylist/src/main/java/com/poptato/yesterdaylist/YesterdayListScreen.kt
+++ b/feature/yesterdaylist/src/main/java/com/poptato/yesterdaylist/YesterdayListScreen.kt
@@ -51,7 +51,10 @@ fun YesterdayListScreen(
 
     YesterdayContent(
         uiState = uiState,
-        onClickCloseBtn = { goBackToBacklog() },
+        onClickCloseBtn = {
+            viewModel.updateYesterdayTodoCompletion()
+            goBackToBacklog()
+        },
         onCheckedChange = { id, status ->
             viewModel.onCheckedTodo(id, status)
         },


### PR DESCRIPTION
## 이슈 번호
> 작업이 완료된 이슈의 번호를 기록해주세요.

- close #141 

## 작업내용
> 작업한 내용을 설명해주세요. 왜 수정했는지? 무엇을 구현했는지? 등등

- [x] 오늘, 할 일 페이지 드래그앤드롭 버그 수정
- [x] 반복 할 일 텍스트 뒤에 . 제거
- [x] 할 일 수정 텍스트 필드 포커스 비활성화 로직 수정
- [x] 어제 안한 일 x 버튼 메서드 추가
- [x] 어제 안한 일 렌더링 로직 수정
- [x] 기록 페이지 달력 네비게이터 버그 수정
- [x] 카테고리 이모지 바텀시트가 렌더링된 상태에서 뒤로가기 버튼 클릭 시 바텀시트 비활성화

